### PR TITLE
Use webmock

### DIFF
--- a/bin/wfhcli
+++ b/bin/wfhcli
@@ -11,18 +11,18 @@ class WfhCli < Thor
 
   desc 'categories', 'List categories'
   def categories
-    @wfh.display_categories
+    puts @wfh.display_categories
   end
 
   desc 'companies', 'List companies'
   option :page, :default => 1
   def companies
-    @wfh.display_companies(options[:page])
+    puts @wfh.display_companies(options[:page])
   end
 
   desc 'company ID', 'Show company with ID'
   def company(id)
-    @wfh.display_company(id)
+    puts @wfh.display_company(id)
   end
 
   desc 'jobs', 'List jobs'
@@ -30,15 +30,15 @@ class WfhCli < Thor
   option :page, :default => 1
   def jobs
     if options[:category]
-      @wfh.display_jobs(options[:page], options[:category])
+      puts @wfh.display_jobs(options[:page], options[:category])
     else
-      @wfh.display_jobs(options[:page])
+      puts @wfh.display_jobs(options[:page])
     end
   end
 
   desc 'job ID', 'Show job with ID'
   def job(id)
-    @wfh.display_job(id)
+    puts @wfh.display_job(id)
   end
 end
 

--- a/bin/wfhcli
+++ b/bin/wfhcli
@@ -15,7 +15,7 @@ class WfhCli < Thor
   end
 
   desc 'companies', 'List companies'
-  option :page, :default => 1
+  option :page, default: 1
   def companies
     puts @wfh.display_companies(options[:page])
   end
@@ -27,7 +27,7 @@ class WfhCli < Thor
 
   desc 'jobs', 'List jobs'
   option :category
-  option :page, :default => 1
+  option :page, default: 1
   def jobs
     if options[:category]
       puts @wfh.display_jobs(options[:page], options[:category])

--- a/lib/wfhcli.rb
+++ b/lib/wfhcli.rb
@@ -134,19 +134,21 @@ class WfhLib
   end
 
   def display_company(company_id)
-    output = ""
+    output = ''
     company = self.company(company_id)
 
     output << generate_header_and_body('Name', company['name'])
     output << generate_header_and_body('URL', company['url'])
     unless company['country'].nil?
-      output << generate_header_and_body('Headquarters', company['country']['name'])
+      output << generate_header_and_body('Headquarters',
+                                         company['country']['name'])
     end
     unless company['twitter'].nil? || company['twitter'].empty?
       output << generate_header_and_body('Twitter', company['twitter'])
     end
     unless company['showcase_url'].nil? || company['showcase_url'].empty?
-      output << generate_header_and_body('Showcase URL', company['showcase_url'])
+      output << generate_header_and_body('Showcase URL',
+                                         company['showcase_url'])
     end
 
     return output
@@ -170,7 +172,7 @@ class WfhLib
   end
 
   def display_job(job_id)
-    output = ""
+    output = ''
     job = self.job(job_id)
 
     if job['country'].nil? || job['country'].empty?
@@ -188,7 +190,8 @@ class WfhLib
     output << generate_header_and_body('Category', category)
     output << generate_header_and_body('Posted', posted)
     output << generate_header_and_body('Description', job['description'])
-    output << generate_header_and_body('Application Info', job['application_info'])
+    output << generate_header_and_body('Application Info',
+                                       job['application_info'])
     output << generate_header_and_body('Country', country)
     unless job['location'].nil? || job['location'].empty?
       output << generate_header_and_body('Location', job['location'])

--- a/lib/wfhcli.rb
+++ b/lib/wfhcli.rb
@@ -113,7 +113,7 @@ class WfhLib
   # TODO: Make private once we are able to properly test methods which use this
   # method.
   def generate_header_and_body(title, body)
-    "#{@shell.set_color(title, @title_colour)}\n#{body}"
+    "#{@shell.set_color(title, @title_colour)}\n#{body}\n"
   end
 
   def display_categories
@@ -127,26 +127,29 @@ class WfhLib
         content << [category['id'], category['name']]
       end
 
-      puts generate_table(content)
+      generate_table(content)
     else
-      puts 'No categories found'
+      'No categories found'
     end
   end
 
   def display_company(company_id)
+    output = ""
     company = self.company(company_id)
 
-    puts generate_header_and_body('Name', company['name'])
-    puts generate_header_and_body('URL', company['url'])
+    output << generate_header_and_body('Name', company['name'])
+    output << generate_header_and_body('URL', company['url'])
     unless company['country'].nil?
-      puts generate_header_and_body('Headquarters', company['country']['name'])
+      output << generate_header_and_body('Headquarters', company['country']['name'])
     end
     unless company['twitter'].nil? || company['twitter'].empty?
-      puts generate_header_and_body('Twitter', company['twitter'])
+      output << generate_header_and_body('Twitter', company['twitter'])
     end
     unless company['showcase_url'].nil? || company['showcase_url'].empty?
-      puts generate_header_and_body('Showcase URL', company['showcase_url'])
+      output << generate_header_and_body('Showcase URL', company['showcase_url'])
     end
+
+    return output
   end
 
   def display_companies(page)
@@ -160,13 +163,14 @@ class WfhLib
         content << [company['id'], company['name']]
       end
 
-      puts generate_table(content)
+      generate_table(content)
     else
-      puts 'No companies found'
+      'No companies found'
     end
   end
 
   def display_job(job_id)
+    output = ""
     job = self.job(job_id)
 
     if job['country'].nil? || job['country'].empty?
@@ -180,15 +184,17 @@ class WfhLib
     category = "#{job['category']['name']} (#{job['category']['id']})"
     posted = format_date(job['created_at'], true)
 
-    puts generate_header_and_body('Title', title)
-    puts generate_header_and_body('Category', category)
-    puts generate_header_and_body('Posted', posted)
-    puts generate_header_and_body('Description', job['description'])
-    puts generate_header_and_body('Application Info', job['application_info'])
-    puts generate_header_and_body('Country', country)
+    output << generate_header_and_body('Title', title)
+    output << generate_header_and_body('Category', category)
+    output << generate_header_and_body('Posted', posted)
+    output << generate_header_and_body('Description', job['description'])
+    output << generate_header_and_body('Application Info', job['application_info'])
+    output << generate_header_and_body('Country', country)
     unless job['location'].nil? || job['location'].empty?
-      puts generate_header_and_body('Location', job['location'])
+      output << generate_header_and_body('Location', job['location'])
     end
+
+    return output
   end
 
   def display_jobs(page, category_id=nil)
@@ -206,9 +212,9 @@ class WfhLib
                     truncate(job['title'], 30)]
       end
 
-      puts generate_table(content)
+      generate_table(content)
     else
-      puts 'No jobs found'
+      'No jobs found'
     end
   end
 

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -1,9 +1,11 @@
 require 'test/unit'
+require 'webmock/test_unit'
 require 'wfhcli'
 
 class TestWfhLib < Test::Unit::TestCase
   def setup
     @wfh = WfhLib.new
+    @headers = { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip, deflate', 'User-Agent' => 'wfhcli' }
   end
 
   def test_format_date
@@ -25,12 +27,109 @@ class TestWfhLib < Test::Unit::TestCase
 
   def test_generate_header_and_body
     actual_output = @wfh.generate_header_and_body('Test', 'test')
-    expected_output = "\e[35mTest\e[0m\ntest"
+    expected_output = "\e[35mTest\e[0m\ntest\n"
     assert_equal actual_output, expected_output
   end
 
   def test_truncate
     str = 'This is a test string which we will truncate'
     assert_equal @wfh.truncate(str, 10), 'This is...'
+  end
+
+  def test_display_categories
+    response = [
+      { 'id' => 1, 'name' => 'Test category' },
+      { 'id' => 2, 'name' => 'Test category 2' }
+    ]
+    stub_request(:get, "#{@wfh.url}/categories").
+      with(headers: @headers).
+        to_return(status: 200, body: JSON.dump(response), headers: {})
+    output = "| \e[35mID\e[0m | \e[35mName           \e[0m |\n"
+    output << "|----|-----------------|\n"
+    output << "| 1  | Test category   |\n"
+    output << "| 2  | Test category 2 |\n"
+    assert_equal @wfh.display_categories, output
+  end
+
+  def test_display_company
+    response = {
+      'id' => 1,
+      'name' => 'Test company',
+      'url' => 'http://www.test.com',
+      'twitter' => 'test_company',
+      'showcase_url' => ''
+    }
+    stub_request(:get, "#{@wfh.url}/companies/1").
+      with(headers: @headers).
+        to_return(status: 200, body: JSON.dump(response), headers: {})
+    output = "\e[35mName\e[0m\nTest company\n"
+    output << "\e[35mURL\e[0m\nhttp://www.test.com\n"
+    output << "\e[35mTwitter\e[0m\ntest_company\n"
+
+    assert_equal @wfh.display_company(1), output
+  end
+
+  def test_display_companies
+    response = [
+      { 'id' => 1, 'name' => 'Test company' },
+      { 'id' => 2, 'name' => 'Test company 2' }
+    ]
+    stub_request(:get, "#{@wfh.url}/companies?page=1").
+      with(headers: @headers).
+        to_return(status: 200, body: JSON.dump(response), headers: {})
+    output = "| \e[35mID\e[0m | \e[35mName          \e[0m |\n"
+    output << "|----|----------------|\n"
+    output << "| 1  | Test company   |\n"
+    output << "| 2  | Test company 2 |\n"
+    assert_equal @wfh.display_companies(1), output
+  end
+
+  def test_display_job
+    response = {
+      'id' => 1,
+      'title' => 'Test title',
+      'description' => 'Test description',
+      'created_at' => '2015-01-07T21:51:36.000Z',
+      'location' => '',
+      'paid' => true,
+      'application_info' => 'E-mail test@test.com',
+      'company' => { 'id' => 1, 'name' => 'Test company' },
+      'category' => { 'id' => 1, 'name' => 'Test category' }
+    }
+    stub_request(:get, "#{@wfh.url}/jobs/1").
+      with(headers: @headers).
+        to_return(status: 200, body: JSON.dump(response), headers: {})
+    output = "\e[35mTitle\e[0m\nTest title @ Test company (1)\n"
+    output << "\e[35mCategory\e[0m\nTest category (1)\n"
+    output << "\e[35mPosted\e[0m\n2015-01-07 21:51\n"
+    output << "\e[35mDescription\e[0m\nTest description\n"
+    output << "\e[35mApplication Info\e[0m\nE-mail test@test.com\n"
+    output << "\e[35mCountry\e[0m\nAnywhere\n"
+    assert_equal @wfh.display_job(1), output
+  end
+
+  def test_display_jobs
+    response = [
+      { 'id' => 1,
+        'title' => 'Test title',
+        'created_at' => '2015-01-07T21:51:36.000Z',
+        'company' => { 'id' => 1, 'name' => 'Test company' },
+        'category' => { 'id' => 1, 'name' => 'Test category' }
+      },
+      { 'id' => 2,
+        'title' => 'Test title 2',
+        'created_at' => '2015-01-07T21:51:36.000Z',
+        'company' => { 'id' => 2, 'name' => 'Test company 2' },
+        'category' => { 'id' => 2, 'name' => 'Test category 2' }
+      }
+    ]
+    stub_request(:get, "#{@wfh.url}/jobs?page=1").
+      with(headers: @headers).
+        to_return(status: 200, body: JSON.dump(response), headers: {})
+    output = "| \e[35mID\e[0m | \e[35mPosted    \e[0m | \e[35mCategory           \e[0m | \e[35mCompany           \e[0m | \e[35mTitle       \e[0m |\n"
+    output << "|----|------------|---------------------|--------------------|--------------|\n"
+    output << "| 1  | 2015-01-07 | Test category (1)   | Test company (1)   | Test title   |\n"
+    output << "| 2  | 2015-01-07 | Test category 2 (2) | Test company 2 (2) | Test title 2 |\n"
+    assert_equal @wfh.display_jobs(1), output
   end
 end

--- a/wfhcli.gemspec
+++ b/wfhcli.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.add_runtime_dependency 'rest-client'
   s.add_runtime_dependency 'thor'
+  s.development_dependency 'webmock'
 end


### PR DESCRIPTION
This change introduces the use of webmock so we can properly test the
public interfaces.  Subsequent commits will make some methods private
and we will then stop testing them.
